### PR TITLE
Pin pylint to 3.0.1 to be aligned with Graal version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1799,17 +1799,17 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pylint"
-version = "3.0.2"
+version = "3.0.1"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "pylint-3.0.2-py3-none-any.whl", hash = "sha256:60ed5f3a9ff8b61839ff0348b3624ceeb9e6c2a92c514d81c9cc273da3b6bcda"},
-    {file = "pylint-3.0.2.tar.gz", hash = "sha256:0d4c286ef6d2f66c8bfb527a7f8a629009e42c99707dec821a03e1b51a4c1496"},
+    {file = "pylint-3.0.1-py3-none-any.whl", hash = "sha256:9c90b89e2af7809a1697f6f5f93f1d0e518ac566e2ac4d2af881a69c13ad01ea"},
+    {file = "pylint-3.0.1.tar.gz", hash = "sha256:81c6125637be216b4652ae50cc42b9f8208dfb725cdc7e04c48f6902f4dbdf40"},
 ]
 
 [package.dependencies]
-astroid = ">=3.0.1,<=3.1.0-dev0"
+astroid = ">=3.0.0,<=3.1.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -2401,4 +2401,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "da18e57f36261c906ff01545a060341cd7c4d608f2baca82a8cd3f3771efe3d0"
+content-hash = "cbcd42c8acbaf5e765aa2e6eeb937a6990227ba36ca1cfeeae509e6d67aebebd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ grimoire-elk = { version = ">=0.106.0", allow-prereleases = true}
 perceval-public-inbox = { version = ">=0.1.1", allow-prereleases = true }
 
 charset-normalizer = "3.3.0"
+pylint = "3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^4.0.1"

--- a/releases/unreleased/pin-charset-normalized-dependency.yml
+++ b/releases/unreleased/pin-charset-normalized-dependency.yml
@@ -1,7 +1,8 @@
 ---
-title: Pin charset-normalized dependency
+title: Pin charset-normalized and pylint dependencies
 category: dependency
 author: null
 issue: null
 notes: >
-  Pin charset-normalized package to be aligned with Perceval version.
+  Pin charset-normalized package to be aligned with Perceval version,
+  and pylint to be aligned with Graal.


### PR DESCRIPTION
Pin pylint to 3.0.1 to be aligned with Graal version