### PR TITLE
Valkey migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,11 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
-      redis:
-        image: redis
+      valkey:
+        image: valkey/valkey:8
         ports:
           - 6379:6379
-        options: --health-cmd="redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd="valkey-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
       opensearch:
         image: opensearchproject/opensearch:${{ matrix.opensearch-version }}
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,11 +31,11 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
-      redis:
-        image: redis
+      valkey:
+        image: valkey/valkey:8
         ports:
           - 6379:6379
-        options: --health-cmd="redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd="valkey-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
       opensearch:
         image: opensearchproject/opensearch:${{ matrix.opensearch-version }}
         env:


### PR DESCRIPTION
Replace redis service with valkey in release and tests workflows.