### PR TITLE
[pontoon] New study for Pontoon to obtain the translation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,20 @@ studies = [ enrich_demography:topicbox ]  # (optional)
 ### Pontoon
 
 Web-based localization platform that facilitates collaborative
-translation of software and documentation
+translation of software and documentation.
+
+To obtain the actions performed by users on a Pontoon server, you need the
+server's URL, a project and the `sessionid` cookie. To get the `sessionid`
+cookie, log in to the Pontoon server. Then, open the browser's developer
+tools and copy the `sessionid` cookie from the cookies store or the network
+requests.
 
 - `projects.json`
 ```
 {
     "Example": {
         "pontoon": [
-            "https://pontoon.mozilla.org af",
-            "https://pontoon.mozilla.org es"
+            "https://pontoon.mozilla.org thunderbird"
         ]
     }
 }
@@ -74,15 +79,19 @@ translation of software and documentation
 [pontoon]
 raw_index = pontoon_raw
 enriched_index = pontoon_enriched
-studies = [ enrich_demography:pontoon ]  # (optional)
+session-id = xxxx
+studies = [ enrich_demography:pontoon, enrich_latest_translation_status:pontoon ]  # (optional)
 
 [enrich_demography:pontoon]  # (optional)
+
+[enrich_latest_translation_status:pontoon]  # (optional)
+out_index = pontoon_translation_status_1
 ```
 
 
 ## Requirements
 
- * Python >= 3.9
+ * Python >= 3.10
 
 You will also need some other libraries for running the tool, you can find the
 whole list of dependencies in [pyproject.toml](pyproject.toml) file.

--- a/releases/unreleased/pontoon-study-for-latest-translation-status.yml
+++ b/releases/unreleased/pontoon-study-for-latest-translation-status.yml
@@ -1,0 +1,10 @@
+---
+title: Pontoon study for latest translation status
+category: added
+author: null
+issue: null
+notes: >
+  Create a new Pontoon study to obtain the translation
+  status for each entity-locale pair. It fetches the most
+  recent user actions and determines the entity status.
+  It creates a new index with the last action for each entity.

--- a/schema/pontoon.csv
+++ b/schema/pontoon.csv
@@ -1,91 +1,58 @@
-name,type
-approved_user_bot,boolean
-approved_user_domain,string
-approved_user_gender,string
-approved_user_gender_acc,number
-approved_user_id,string
-approved_user_multi_org_names,string
-approved_user_name,string
-approved_user_org_name,string
-approved_user_user_name,string
-approved_user_uuid,string
-author_bot,boolean
-author_gender,string
-author_gender_acc,number
-author_id,string
-author_multi_org_names,string
-author_name,string
-author_org_name,string
-author_user_name,string
-author_uuid,string
-context,string
-date_created,date
-format,string
-grimoire_creation_date,date
-group_comment,string
-id,string
-is_pontoon_message,number
-key,string
-locale,string
-machinery_original,string
-machinery_original_analyzed,string
-obsolete,boolean
-order,number
-origin,string
-original,string
-original_analyzed,string
-path,string
-pk,number
-project,string
-project_1,string
-project_name,string
-project_pk,number
-project_slug,string
-readonly,boolean
-rejected_user_bot,boolean
-rejected_user_domain,string
-rejected_user_gender,string
-rejected_user_gender_acc,number
-rejected_user_id,string
-rejected_user_multi_org_names,string
-rejected_user_name,string
-rejected_user_org_name,string
-rejected_user_user_name,string
-rejected_user_uuid,string
-resource_comment,string
-review_status,keyword
-tag,string
-translation_approved,boolean
-translation_approved_user,string
-translation_comments,number
-translation_date,date
-translation_errors,number
-translation_fuzzy,boolean
-translation_machinery_sources,string
-translation_pk,number
-translation_pretranslated,boolean
-translation_rejected,boolean
-translation_rejected_user,string
-translation_string,string
-translation_string_analyzed,string
-translation_uid,number
-translation_user,string
-translation_username,string
-translation_warnings,number
-url,string
-user_bot,boolean
-user_domain,string
-user_gender,string
-user_gender_acc,number
-user_id,string
-user_multi_org_names,string
-user_name,string
-user_org_name,string
-user_user_name,string
-user_uuid,string
-uuid,string
-metadata__enriched_on,date
-metadata__gelk_backend_name,string
-metadata__gelk_version,string
-metadata__timestamp,date
-metadata__updated_on,date
+field,type,description
+author_bot,boolean,"True if the given author is identified as a bot (from SortingHat profile)."
+author_domain,string,Email domain or organization domain of the author
+author_gender,string,"Author gender, based on her name, from SortingHat."
+author_gender_acc,number,"Author gender accuracy from SortingHat."
+author_id,string,Unique identifier for the author
+author_multi_org_names,string,List of organization names associated with the author
+author_name,string,Author name
+author_org_name,string,Primary organization name of the author
+author_user_name,string,Author username
+author_uuid,string,"Author UUID."
+date,date,Date of the user action
+demography_max_date,date,Latest date considered in author demographic data
+demography_min_date,date,Earliest date considered in author demographic data
+entity_key,string,Key identifying the Pontoon entity (string to translate)
+entity_pk,number,Primary key for the Pontoon entity (string to translate)
+grimoire_creation_date,date,User action creation date
+id,string,Unique user action ID
+is_pontoon_action,number,Flag indicating if this record corresponds to a Pontoon action
+locale,string,Locale code
+entity_uid,string,ID to identify a specific translation formed as project:locale:entity
+locale_name,string,Human-readable name of the locale
+metadata__timestamp,date,"Date when the item was stored in RAW index."
+metadata__updated_on,date,"Date when the item was updated on its original data source."
+origin,string,"Original URL where the action was retrieved from."
+project,string,GrimoireLab project name
+project_1,string,"Project (if more than one level is allowed in project hierarchy)."
+project_name,string,Pontoon project name
+project_pk,number,Primary key for the Pontoon project
+project_slug,string,Slugified Pontoon project name used in URLs
+resource_format,string,File format of the translation resource
+resource_path,string,Path or identifier for the translation resource
+resource_pk,number,Primary key for the translation resource
+system_user,boolean,Whether the Pontoon user is a system account
+tag,string,Perceval tag
+translation_approved,boolean,Whether the translation was approved
+translation_errors,number,Number of detected translation errors
+translation_fuzzy,boolean,Whether the translation was marked as fuzzy
+translation_pk,number,Primary key for the translation
+translation_pretranslated,boolean,Whether the translation was pre-translated automatically
+translation_rejected,boolean,Whether the translation was rejected
+translation_string,string,Raw translation string
+translation_string_analyzed,string,Analyzed version of the translation string for full-text search
+translation_warnings,number,Number of translation warnings
+type,string,Type or category of the user action
+url,string,URL to the Pontoon entity
+user_bot,boolean,Whether the user is identified as a bot
+user_domain,string,Email or organization domain of the user
+user_gender,string,Predicted gender of the user
+user_gender_acc,number,Confidence score for the user's gender prediction
+user_id,string,Unique identifier for the user
+user_multi_org_names,string,List of organization names associated with the user
+user_name,string,Full name of the user
+user_org_name,string,Primary organization name of the user
+user_pk,number,Primary key for the user in Pontoon
+user_user_name,string,Username of the user
+user_uuid,string,UUID of the user
+uuid,string,"Perceval UUID."

--- a/tests/data/pontoon.json
+++ b/tests/data/pontoon.json
@@ -214,5 +214,182 @@
     "timestamp":1.733998578168747E9,
     "updated_on":1.479372383174E9,
     "uuid":"aa1e5d86ccefc058ee12408cc04d2a1cef26466e"
+  },
+  {
+    "backend_name": "Pontoon",
+    "backend_version": "0.2.0",
+    "perceval_version": "1.4.0",
+    "timestamp": 1761654470.340331,
+    "origin": "https://pontoon.mozilla.org/p1",
+    "uuid": "e8732ec78347c07954f0183ec6ec771aa6528d2f",
+    "updated_on": 1631010656.12,
+    "classified_fields_filtered": null,
+    "category": "action",
+    "search_fields": {
+      "item_id": "action:p1:el:83090:2470935:translation:rejected"
+    },
+    "tag": "https://pontoon.mozilla.org/p1",
+    "data": {
+      "type": "translation:rejected",
+      "date": "2021-09-07T10:30:56.120Z",
+      "user": {
+        "pk": 976,
+        "name": "User 3",
+        "username": "aETvvMUPqUdEyG1xkuTEtvUgA1c",
+        "system_user": false
+      },
+      "locale": {
+        "pk": 88,
+        "code": "el",
+        "name": "Greek"
+      },
+      "entity": {
+        "pk": 83090,
+        "key": [
+          "confirmDuplicateFolderRename"
+        ]
+      },
+      "resource": {
+        "pk": 1045,
+        "path": "mail/chrome/messenger/messenger.properties",
+        "format": "properties"
+      },
+      "translation": {
+        "pk": 2470935,
+        "string": "Sample string 2",
+        "approved": false,
+        "rejected": true,
+        "pretranslated": false,
+        "fuzzy": false,
+        "errors": [],
+        "warnings": []
+      },
+      "project": {
+        "pk": 53,
+        "slug": "p1",
+        "name": "Project 1"
+      },
+      "id": "action:p1:el:83090:2470935:translation:rejected"
+    },
+    "metadata__updated_on": "2021-09-07T10:30:56.120000+00:00",
+    "metadata__timestamp": "2025-10-28T12:27:50.340331+00:00"
+  },
+  {
+    "backend_name": "Pontoon",
+    "backend_version": "0.2.0",
+    "perceval_version": "1.4.0",
+    "timestamp": 1761654470.340423,
+    "origin": "https://pontoon.mozilla.org/p1",
+    "uuid": "6f01c914800454ec560b94d70cae908c70ff0ad7",
+    "updated_on": 1631010656.201,
+    "classified_fields_filtered": null,
+    "category": "action",
+    "search_fields": {
+      "item_id": "action:p1:el:83090:8516196:translation:created"
+    },
+    "tag": "https://pontoon.mozilla.org/p1",
+    "data": {
+      "type": "translation:created",
+      "date": "2021-09-07T10:30:56.201Z",
+      "user": {
+        "pk": 976,
+        "name": "User 3",
+        "username": "aETvvMUPqUdEyG1xkuTEtvUgA1c",
+        "system_user": false
+      },
+      "locale": {
+        "pk": 88,
+        "code": "el",
+        "name": "Greek"
+      },
+      "entity": {
+        "pk": 83090,
+        "key": [
+          "confirmDuplicateFolderRename"
+        ]
+      },
+      "resource": {
+        "pk": 1045,
+        "path": "mail/chrome/messenger/messenger.properties",
+        "format": "properties"
+      },
+      "translation": {
+        "pk": 8516196,
+        "string": "Sample string 2",
+        "approved": true,
+        "rejected": false,
+        "pretranslated": false,
+        "fuzzy": false,
+        "errors": [],
+        "warnings": []
+      },
+      "project": {
+        "pk": 53,
+        "slug": "p1",
+        "name": "Project 1"
+      },
+      "id": "action:p1:el:83090:8516196:translation:created"
+    },
+    "metadata__updated_on": "2021-09-07T10:30:56.201000+00:00",
+    "metadata__timestamp": "2025-10-28T12:27:50.340423+00:00"
+  },
+  {
+    "backend_name": "Pontoon",
+    "backend_version": "0.2.0",
+    "perceval_version": "1.4.0",
+    "timestamp": 1761662951.873425,
+    "origin": "https://pontoon.mozilla.org/p1",
+    "uuid": "09235bbbddcb664d6fa03b20538428280c8cec9f",
+    "updated_on": 1718904913.794,
+    "classified_fields_filtered": null,
+    "category": "action",
+    "search_fields": {
+      "item_id": "action:p1:cy:307116:10209975:translation:created"
+    },
+    "tag": "https://pontoon.mozilla.org/p1",
+    "data": {
+      "type": "translation:created",
+      "date": "2024-06-20T17:35:13.794Z",
+      "user": {
+        "pk": 7048,
+        "name": "Sync",
+        "username": "pontoon-sync",
+        "system_user": true
+      },
+      "locale": {
+        "pk": 266,
+        "code": "cy",
+        "name": "Welsh"
+      },
+      "entity": {
+        "pk": 307116,
+        "key": [
+          "windowtitle-mixed-copy"
+        ]
+      },
+      "resource": {
+        "pk": 7711,
+        "path": "calendar/calendar/calendar-occurrence-prompt.ftl",
+        "format": "fluent"
+      },
+      "translation": {
+        "pk": 10209975,
+        "string": "windowtitle-mixed-copy = Copïo Eitemau sy'n Ailadrodd\n",
+        "approved": true,
+        "rejected": false,
+        "pretranslated": false,
+        "fuzzy": false,
+        "errors": [],
+        "warnings": []
+      },
+      "project": {
+        "pk": 53,
+        "slug": "p1",
+        "name": "Project 1"
+      },
+      "id": "action:p1:cy:307116:10209975:translation:created"
+    },
+    "metadata__updated_on": "2024-06-20T17:35:13.794000+00:00",
+    "metadata__timestamp": "2025-10-28T14:49:11.873425+00:00"
   }
 ]


### PR DESCRIPTION
This adds a new study to obtain the latest translation status for each entity-locale pair. It fetches the most recent user actions and determines the current status of the translation.

The new study is called `enrich_latest_translation_status` and can be configured with the `out_index` and the `alias`. The default alias is `pontoon_latest_translation_status`.

Fixes https://github.com/chaoss/grimoirelab-elk/issues/1209